### PR TITLE
* Removed warnings for check_tree being of wrong type.

### DIFF
--- a/src/spat-preconditions.adb
+++ b/src/spat-preconditions.adb
@@ -15,22 +15,27 @@ package body SPAT.Preconditions is
    ---------------------------------------------------------------------------
    --  Ensure_Field
    ---------------------------------------------------------------------------
-   function Ensure_Field (Object : in JSON_Value;
-                          Field  : in UTF8_String;
-                          Kind   : in JSON_Value_Type) return Boolean is
+   function Ensure_Field (Object      : in JSON_Value;
+                          Field       : in UTF8_String;
+                          Kind        : in JSON_Value_Type;
+                          Is_Optional : in Boolean := False) return Boolean is
    begin
       if not Object.Has_Field (Field => Field) then
-         Log.Warning
-           (Message => "Expected field """ & Field & """ not present!");
+         if not Is_Optional then
+            Log.Warning
+              (Message => "Expected field """ & Field & """ not present!");
+         end if;
 
          return False;
       end if;
 
       if Object.Get (Field => Field).Kind /= Kind then
-         Log.Warning
-           (Message =>
-              "Field """ & Field & """ not of expected type """ & Kind'Image &
-              """!");
+         if not Is_Optional then
+            Log.Warning
+              (Message =>
+                 "Field """ & Field & """ not of expected type """ & Kind'Image &
+                 """!");
+         end if;
 
          return False;
       end if;

--- a/src/spat-preconditions.ads
+++ b/src/spat-preconditions.ads
@@ -28,11 +28,14 @@ package SPAT.Preconditions is
    --
    --  Check that the given JSON object contains an object named Field with
    --  type of Kind.
+   --  If the field is not found or the type is different from the expected
+   --  one, a warning is issued, unless Is_Optional is True.
    --  Returns True if so, False otherwise.
    ---------------------------------------------------------------------------
-   function Ensure_Field (Object : in JSON_Value;
-                          Field  : in UTF8_String;
-                          Kind   : in JSON_Value_Type) return Boolean;
+   function Ensure_Field (Object      : in JSON_Value;
+                          Field       : in UTF8_String;
+                          Kind        : in JSON_Value_Type;
+                          Is_Optional : in Boolean := False) return Boolean;
 
    ---------------------------------------------------------------------------
    --  Ensure_Field

--- a/src/spat-proof_item.adb
+++ b/src/spat-proof_item.adb
@@ -23,10 +23,13 @@ package body SPAT.Proof_Item is
    ---------------------------------------------------------------------------
    --  Add_To_Tree
    ---------------------------------------------------------------------------
-   procedure Add_To_Tree (Object : in     JSON_Value;
-                          Tree   : in out Entity.Tree.T;
-                          Parent : in     Entity.Tree.Cursor)
+   procedure Add_To_Tree (Object  : in     JSON_Value;
+                          Version : in     File_Version;
+                          Tree    : in out Entity.Tree.T;
+                          Parent  : in     Entity.Tree.Cursor)
    is
+      pragma Unreferenced (Version); --  Only for precondition.
+
       Max_Time    : Duration := 0.0;
       Total_Time  : Duration := 0.0;
       Checks_List : Checks_Lists.Vector;

--- a/src/spat-proof_item.ads
+++ b/src/spat-proof_item.ads
@@ -28,12 +28,17 @@ package SPAT.Proof_Item is
    ---------------------------------------------------------------------------
    --  Has_Required_Fields
    ---------------------------------------------------------------------------
-   function Has_Required_Fields (Object : in JSON_Value) return Boolean is
+   function Has_Required_Fields (Object  : in JSON_Value;
+                                 Version : in File_Version) return Boolean is
       (Entity_Location.Has_Required_Fields (Object => Object) and
        Preconditions.Ensure_Rule_Severity (Object => Object) and
-       Preconditions.Ensure_Field (Object => Object,
-                                   Field  => Field_Names.Check_Tree,
-                                   Kind   => JSON_Array_Type));
+       Preconditions.Ensure_Field (Object      => Object,
+                                   Field       => Field_Names.Check_Tree,
+                                   Kind        => JSON_Array_Type,
+                                   Is_Optional =>
+                                     (case Version is
+                                         when GNAT_CE_2019 => False,
+                                         when GNAT_CE_2020 => True)));
 
    type T is new Entity_Location.T with private;
 
@@ -45,15 +50,18 @@ package SPAT.Proof_Item is
    ---------------------------------------------------------------------------
    overriding
    function Create (Object : in JSON_Value) return T with
-     Pre => Has_Required_Fields (Object => Object);
+     Pre => Has_Required_Fields (Object  => Object,
+                                 Version => GNAT_CE_2019);
 
    ---------------------------------------------------------------------------
    --  Add_To_Tree
    ---------------------------------------------------------------------------
-   procedure Add_To_Tree (Object : in     JSON_Value;
-                          Tree   : in out Entity.Tree.T;
-                          Parent : in     Entity.Tree.Cursor) with
-     Pre => Has_Required_Fields (Object => Object);
+   procedure Add_To_Tree (Object  : in     JSON_Value;
+                          Version : in File_Version;
+                          Tree    : in out Entity.Tree.T;
+                          Parent  : in     Entity.Tree.Cursor) with
+     Pre => Has_Required_Fields (Object  => Object,
+                                 Version => Version);
 
    ---------------------------------------------------------------------------
    --  Slower_Than

--- a/src/spat-spark_info.adb
+++ b/src/spat-spark_info.adb
@@ -78,8 +78,9 @@ package body SPAT.Spark_Info is
    ---------------------------------------------------------------------------
    --  Map_Proof_Elements
    ---------------------------------------------------------------------------
-   procedure Map_Proof_Elements (This : in out T;
-                                 Root : in     JSON_Array);
+   procedure Map_Proof_Elements (This    : in out T;
+                                 Version : in     File_Version;
+                                 Root    : in     JSON_Array);
 
    ---------------------------------------------------------------------------
    --  Map_Sloc_Elements
@@ -451,8 +452,9 @@ package body SPAT.Spark_Info is
    ---------------------------------------------------------------------------
    --  Map_Proof_Elements
    ---------------------------------------------------------------------------
-   procedure Map_Proof_Elements (This : in out T;
-                                 Root : in     JSON_Array) is
+   procedure Map_Proof_Elements (This    : in out T;
+                                 Version : in     File_Version;
+                                 Root    : in     JSON_Array) is
    begin
       for I in 1 .. GNATCOLL.JSON.Length (Arr => Root) loop
          declare
@@ -483,7 +485,8 @@ package body SPAT.Spark_Info is
                      begin
                         if Update_At /= Analyzed_Entities.No_Element then
                            if
-                             Proof_Item.Has_Required_Fields (Object => Element)
+                             Proof_Item.Has_Required_Fields (Object  => Element,
+                                                             Version => Version)
                            then
                               declare
                                  Reference : constant
@@ -492,9 +495,10 @@ package body SPAT.Spark_Info is
                                        (Position => Update_At);
                               begin
                                  Proof_Item.Add_To_Tree
-                                   (Object => Element,
-                                    Tree   => Reference.The_Tree,
-                                    Parent => Reference.Proofs);
+                                   (Object  => Element,
+                                    Version => Version,
+                                    Tree    => Reference.The_Tree,
+                                    Parent  => Reference.Proofs);
 
                                  --  Update parent sentinel with new proof
                                  --  times.
@@ -665,7 +669,8 @@ package body SPAT.Spark_Info is
                                     Kind   => JSON_Array_Type)
       then
          This.Map_Proof_Elements
-           (Root => Root.Get (Field => Field_Names.Proof));
+           (Root    => Root.Get (Field => Field_Names.Proof),
+            Version => Version);
       end if;
 
       if

--- a/test/spat.test-sparknacl.raca.template
+++ b/test/spat.test-sparknacl.raca.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 Random                                                    => 0.0 s/0.0 s
 Random.Random_Byte                                        => 0.0 s/0.0 s
 SPARKNaCl                                                 => 80.0 ms/260.0 ms

--- a/test/spat.test-sparknacl.ract.template
+++ b/test/spat.test-sparknacl.ract.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 SPARKNaCl.Sign.Sign                                       => 57.6 s/489.2 s
 SPARKNaCl.Sign.ModL.Eliminate_Limbs_62_To_32              => 9.2 s/148.2 s
 SPARKNaCl.Omultiply                                       => 19.1 s/28.6 s

--- a/test/spat.test-sparknacl.rfca.template
+++ b/test/spat.test-sparknacl.rfca.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 SPARKNaCl.ASR_16                                          => 5.7 s/5.9 s
 SPARKNaCl.ASR_4                                           => 1.2 s/1.4 s
 SPARKNaCl.ASR_8                                           => 3.3 s/3.5 s

--- a/test/spat.test-sparknacl.rfct.template
+++ b/test/spat.test-sparknacl.rfct.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 SPARKNaCl.Sign.Sign                                       => 57.6 s/489.2 s
 SPARKNaCl.Omultiply                                       => 19.1 s/28.6 s
 SPARKNaCl.Car.Nearlynormal_To_Normal                      => 1.4 s/17.5 s

--- a/test/spat.test-sparknacl.ruca.template
+++ b/test/spat.test-sparknacl.ruca.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 SPARKNaCl.ASR_16                                          => 5.7 s/5.9 s
 SPARKNaCl.ASR_4                                           => 1.2 s/1.4 s
 SPARKNaCl.ASR_8                                           => 3.3 s/3.5 s

--- a/test/spat.test-sparknacl.ruct.template
+++ b/test/spat.test-sparknacl.ruct.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 SPARKNaCl.Sign.Sign                                       => 57.6 s/489.2 s
 SPARKNaCl.Car.Nearlynormal_To_Normal                      => 1.4 s/17.5 s
 SPARKNaCl.ASR_16                                          => 5.7 s/5.9 s

--- a/test/spat.test-sparknacl.s.template
+++ b/test/spat.test-sparknacl.s.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 sparknacl-secretbox.spark => (Flow  => 7.6 ms,
                               Proof => 10.3 s)
 sparknacl-cryptobox.spark => (Flow  => 69.2 ms,

--- a/test/spat.test-sparknacl.sradca.template
+++ b/test/spat.test-sparknacl.sradca.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 random.spark              => (Flow  => 517.0 µs,
                               Proof => 0.0 s)
 sparknacl.spark           => (Flow  => 164.3 ms,

--- a/test/spat.test-sparknacl.sradct.template
+++ b/test/spat.test-sparknacl.sradct.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 sparknacl-sign.spark      => (Flow  => 253.6 ms,
                               Proof => 764.5 s)
 sparknacl-car.spark       => (Flow  => 86.1 ms,

--- a/test/spat.test-sparknacl.srfdca.template
+++ b/test/spat.test-sparknacl.srfdca.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 random.spark              => (Flow  => 517.0 µs,
                               Proof => 0.0 s)
 sparknacl.spark           => (Flow  => 164.3 ms,

--- a/test/spat.test-sparknacl.srfdct.template
+++ b/test/spat.test-sparknacl.srfdct.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 sparknacl-sign.spark      => (Flow  => 253.6 ms,
                               Proof => 764.5 s)
 sparknacl-car.spark       => (Flow  => 86.1 ms,

--- a/test/spat.test-sparknacl.srjdca.template
+++ b/test/spat.test-sparknacl.srjdca.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 random.spark              => (Flow  => 517.0 µs,
                               Proof => 0.0 s)
 sparknacl.spark           => (Flow  => 164.3 ms,

--- a/test/spat.test-sparknacl.srjdct.template
+++ b/test/spat.test-sparknacl.srjdct.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 sparknacl-sign.spark      => (Flow  => 253.6 ms,
                               Proof => 764.5 s)
 sparknacl-car.spark       => (Flow  => 86.1 ms,

--- a/test/spat.test-sparknacl.srudca.template
+++ b/test/spat.test-sparknacl.srudca.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 random.spark              => (Flow  => 517.0 µs,
                               Proof => 0.0 s)
 sparknacl.spark           => (Flow  => 164.3 ms,

--- a/test/spat.test-sparknacl.srudct.template
+++ b/test/spat.test-sparknacl.srudct.template
@@ -1,14 +1,3 @@
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
-Warning: Field "check_tree" not of expected type "JSON_ARRAY_TYPE"!
 sparknacl-sign.spark      => (Flow  => 253.6 ms,
                               Proof => 764.5 s)
 sparknacl-car.spark       => (Flow  => 86.1 ms,


### PR DESCRIPTION
Warnings not emitted for GNAT CE 2020 files.
Templates updated accordingly.